### PR TITLE
Add Journal Integration for Obsidian Workflow

### DIFF
--- a/src/journal/README.md
+++ b/src/journal/README.md
@@ -1,0 +1,386 @@
+# Journal Integration
+
+Connect comic-engine with your Obsidian journal to visualize journal entries as comic panels and explore themes across time.
+
+## Overview
+
+This integration allows you to:
+1. Mark journal entries in Obsidian for comic-ification
+2. Answer story prompts to flesh out the visual narrative
+3. Export entries as JSON
+4. Import into comic-engine to generate 3D parallax comic scenes
+5. Explore themes across multiple journal entries
+
+## Quick Start
+
+### 1. Set Up Obsidian Template
+
+Copy the template from `templates/obsidian-comic-template.md` to your Obsidian templates folder.
+
+When creating a new journal entry, use this template to get the proper frontmatter structure.
+
+### 2. Mark Passages for Comics
+
+In your journal entry, mark the passage you want to turn into a comic using one of these methods:
+
+**Method A: Explicit markers**
+```markdown
+[Marked passage begins]
+Your meaningful journal passage here...
+[Marked passage ends]
+```
+
+**Method B: Highlight syntax**
+```markdown
+==Your highlighted passage here==
+```
+
+**Method C: Code block**
+````markdown
+```comic
+Your passage in a code block
+```
+````
+
+### 3. Fill in Story Prompts
+
+Update the frontmatter with answers to the story prompts:
+
+```yaml
+---
+comic_candidate: true
+date: 2025-01-15
+themes:
+  - healing
+  - growth
+tags:
+  - journal
+  - to-comic
+visual_style: torn
+emotional_intensity: 7
+
+characters:
+  - myself
+  - my younger self
+dominant_emotion: bittersweet relief
+visual_metaphor: a door opening to light, but with shadows behind
+before_context: Years of carrying this weight alone
+after_context: First steps toward letting it go
+---
+```
+
+### 4. Export to JSON
+
+Export your marked entries to JSON format. See `templates/example-export.json` for the expected structure.
+
+You can do this manually or use an Obsidian plugin (like Dataview or Templater) to automate the export.
+
+### 5. Import into Comic-Engine
+
+```jsx
+import { useJournalEntries, generateThemeSequenceScene } from './journal';
+
+function MyJournalScene() {
+  const { sequences, loadFromSource } = useJournalEntries();
+
+  useEffect(() => {
+    loadFromSource('/path/to/your/exported-journal.json');
+  }, []);
+
+  // Generate scenes from your entries
+  // See JournalExample.jsx for full example
+}
+```
+
+## API Reference
+
+### Schema
+
+#### JournalEntry
+```javascript
+{
+  metadata: {
+    id: string,               // Unique identifier
+    date: string,             // ISO date string
+    themes: string[],         // Array of themes
+    comicCandidate: boolean,  // Whether marked for comic
+    tags: string[],           // Obsidian tags
+    storyPrompts: {
+      characters: string[],        // Who's in the scene
+      dominantEmotion: string,     // Dominant emotion
+      visualMetaphor: string,      // Visual metaphor
+      beforeContext: string,       // What happened before
+      afterContext: string,        // What happens after
+    },
+    visualStyle?: string,     // 'default' | 'polaroid' | 'torn' | 'monitor'
+    emotionalIntensity?: number, // 1-10 scale
+  },
+  content: string,  // Full markdown content
+  excerpt: string,  // Marked passage for comic
+}
+```
+
+#### ThemeSequence
+```javascript
+{
+  theme: string,           // Theme name
+  entryIds: string[],      // Array of entry IDs (chronological)
+  entries: JournalEntry[], // Full entry objects
+  narrativeArc: string,    // Description of theme evolution
+}
+```
+
+### Parser Functions
+
+#### `parseObsidianMarkdown(markdown, filename?)`
+Parses Obsidian markdown with frontmatter into a JournalEntry.
+
+```javascript
+import { parseObsidianMarkdown } from './journal';
+
+const markdown = `---
+comic_candidate: true
+date: 2025-01-15
+themes:
+  - healing
+---
+
+# My Entry
+
+==This is the marked passage==
+`;
+
+const entry = parseObsidianMarkdown(markdown, '2025-01-15.md');
+```
+
+#### `parseBatch(files)`
+Parses multiple markdown files at once.
+
+```javascript
+const files = [
+  { filename: 'entry1.md', content: '...' },
+  { filename: 'entry2.md', content: '...' },
+];
+
+const entries = parseBatch(files);
+```
+
+#### `groupByTheme(entries)`
+Groups entries by theme.
+
+```javascript
+const themeMap = groupByTheme(entries);
+// { healing: [...], growth: [...], ... }
+```
+
+#### `createThemeSequences(themeMap)`
+Creates theme sequences from grouped entries.
+
+```javascript
+const sequences = createThemeSequences(themeMap);
+// [{ theme: 'healing', entries: [...], ... }, ...]
+```
+
+### Scene Generator Functions
+
+#### `generateSceneFromEntry(entry, options?)`
+Generates a scene configuration from a single journal entry.
+
+```javascript
+import { generateSceneFromEntry } from './journal';
+
+const sceneConfig = generateSceneFromEntry(entry, {
+  centerPosition: [0, 0, 0],
+  includeBackground: true,
+});
+```
+
+#### `generateThemeSequenceScene(themeSequence, options?)`
+Generates a scene with multiple panels exploring a theme.
+
+```javascript
+const sceneConfig = generateThemeSequenceScene(sequence, {
+  layout: 'timeline', // 'timeline' | 'spiral' | 'stack'
+});
+```
+
+Layouts:
+- **timeline**: Linear horizontal spread with depth
+- **spiral**: Entries spiral inward/outward
+- **stack**: Stacked in Z-depth
+
+#### `exportAsComponent(sceneConfig)`
+Exports a scene configuration as React component code.
+
+```javascript
+const componentCode = exportAsComponent(sceneConfig);
+// Returns JSX string that can be saved as a .jsx file
+```
+
+### React Hook
+
+#### `useJournalEntries(options?)`
+React hook for managing journal entries.
+
+```javascript
+const {
+  entries,           // All loaded entries
+  themes,            // Grouped by theme
+  sequences,         // Theme sequences
+  loading,           // Loading state
+  error,             // Error state
+
+  // Methods
+  loadFromSource,    // Load from JSON URL
+  parseMarkdownFiles, // Parse markdown files
+  addEntry,          // Add single entry
+  removeEntry,       // Remove by ID
+  updateEntry,       // Update entry
+  getByTheme,        // Get entries for theme
+  getComicCandidates, // Get comic-marked entries
+  getByDateRange,    // Filter by date range
+  clear,             // Clear all entries
+} = useJournalEntries({
+  autoLoad: false,
+  initialEntries: [],
+});
+```
+
+## Visual Styles
+
+The generator maps emotions and visual styles to panel variants:
+
+| Visual Style | Panel Variant | Best For |
+|--------------|---------------|----------|
+| `default` | Standard comic panel | General entries |
+| `polaroid` | Photo-style frame | Nostalgic/memory entries |
+| `torn` | Torn paper effect | Raw/intense emotions |
+| `monitor` | CRT monitor style | Disconnection/digital themes |
+| `borderless` | No border | Clear/present moments |
+
+## Emotional Intensity
+
+The `emotionalIntensity` (1-10) affects visual positioning:
+
+- **1-3**: Far background (z=-200), calm, distant
+- **4-6**: Midground (z=0), present, engaged
+- **7-10**: Foreground (z=150), immediate, intense
+
+## Theme Exploration
+
+The system automatically tracks themes across entries:
+
+1. Tag entries with themes in frontmatter
+2. Multiple entries can share themes
+3. Use `generateThemeSequenceScene()` to create narrative arcs
+4. Explore how themes evolve over time visually
+
+## Example Workflow
+
+1. **Journal in Obsidian** using the template
+2. **Mark meaningful passages** with highlight or markers
+3. **Fill in story prompts** in frontmatter
+4. **Tag with themes** to connect entries
+5. **Export to JSON** when ready
+6. **Import in comic-engine** with `loadFromSource()`
+7. **Generate scenes** from theme sequences
+8. **Navigate visually** through your healing journey
+
+## Integration with Art Therapy Framework
+
+This journal integration is designed to work with art therapy principles:
+
+- **Externalization**: Transform internal experiences into visual form
+- **Narrative**: Build coherent stories from fragmented experiences
+- **Metaphor**: Use visual metaphors to represent complex emotions
+- **Theme Tracking**: See patterns and progress over time
+- **Safety**: Choose what to share and how to represent it
+
+## Advanced Usage
+
+### Custom Visual Mappings
+
+You can customize how emotions map to visuals by modifying `sceneGenerator.js`:
+
+```javascript
+// Add custom emotion -> visual mappings
+function getEmotionalPanelStyle(emotion) {
+  if (emotion.includes('your-custom-emotion')) {
+    return {
+      variant: 'custom-variant',
+      filter: 'your-filter',
+    };
+  }
+  // ...
+}
+```
+
+### Automated Export from Obsidian
+
+Use Dataview or Templater to create automated exports:
+
+```javascript
+// Dataview query example
+TABLE
+  file.name as id,
+  date,
+  themes,
+  comic_candidate,
+  tags
+FROM #to-comic
+WHERE comic_candidate = true
+```
+
+### Dynamic Scene Generation
+
+Generate scenes dynamically based on user interaction:
+
+```javascript
+const [currentTheme, setCurrentTheme] = useState('healing');
+const sequence = sequences.find(s => s.theme === currentTheme);
+const scene = generateThemeSequenceScene(sequence, { layout: 'spiral' });
+```
+
+## Troubleshooting
+
+**Q: My entries aren't being parsed correctly**
+- Check that frontmatter is valid YAML between `---` markers
+- Ensure arrays use the `- item` format
+- Verify boolean values are lowercase `true`/`false`
+
+**Q: Marked passages aren't being extracted**
+- Use one of the three supported marker formats
+- Check for typos in markers (case-insensitive)
+- Ensure markers are on their own lines
+
+**Q: Themes aren't grouping correctly**
+- Themes must be in an array in frontmatter
+- Use consistent theme names across entries
+- Check for typos in theme names
+
+## Files
+
+```
+src/journal/
+├── README.md                 # This file
+├── schema.js                 # Data format definitions
+├── parser.js                 # Obsidian markdown parser
+├── sceneGenerator.js         # Scene generation logic
+├── useJournalEntries.js      # React hook
+├── index.js                  # Main exports
+└── templates/
+    ├── obsidian-comic-template.md   # Obsidian template
+    └── example-export.json          # Example data
+```
+
+## Next Steps
+
+- See `src/pages/JournalExample.jsx` for a complete implementation
+- Customize visual mappings for your needs
+- Create your own layout algorithms
+- Integrate with your existing Obsidian workflow
+- Build narrative sequences across multiple themes
+
+---
+
+**Related**: [Notion Ticket](https://www.notion.so/2fd4d0c655b8816eb5f9f83cc0911430) | [Issue #1](https://github.com/Luan-vP/comic-engine/issues/1)

--- a/src/journal/index.js
+++ b/src/journal/index.js
@@ -1,0 +1,26 @@
+/**
+ * Journal Integration Module
+ *
+ * Main entry point for journal-to-comic functionality
+ */
+
+export {
+  validateJournalEntry,
+  exampleJournalEntry,
+  exampleThemeSequence,
+} from './schema.js';
+
+export {
+  parseObsidianMarkdown,
+  parseBatch,
+  groupByTheme,
+  createThemeSequences,
+} from './parser.js';
+
+export {
+  generateSceneFromEntry,
+  generateThemeSequenceScene,
+  exportAsComponent,
+} from './sceneGenerator.js';
+
+export { useJournalEntries } from './useJournalEntries.js';

--- a/src/journal/parser.js
+++ b/src/journal/parser.js
@@ -1,0 +1,265 @@
+/**
+ * Obsidian Markdown Parser for Journal Integration
+ *
+ * Parses Obsidian markdown files with frontmatter into JournalEntry objects
+ */
+
+/**
+ * Parses YAML frontmatter from markdown
+ * @param {string} markdown - The markdown content
+ * @returns {{ frontmatter: Object, content: string }}
+ */
+function parseFrontmatter(markdown) {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  const match = markdown.match(frontmatterRegex);
+
+  if (!match) {
+    return { frontmatter: {}, content: markdown };
+  }
+
+  const [, frontmatterText, content] = match;
+  const frontmatter = {};
+
+  // Simple YAML parser (for basic key-value pairs and arrays)
+  const lines = frontmatterText.split('\n');
+  let currentKey = null;
+  let currentArray = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Array item
+    if (trimmed.startsWith('- ')) {
+      if (currentArray) {
+        currentArray.push(trimmed.slice(2).trim());
+      }
+      continue;
+    }
+
+    // Key-value pair
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex > 0) {
+      const key = trimmed.slice(0, colonIndex).trim();
+      const value = trimmed.slice(colonIndex + 1).trim();
+
+      if (value === '') {
+        // Start of array
+        currentKey = key;
+        currentArray = [];
+        frontmatter[key] = currentArray;
+      } else if (value === 'true' || value === 'false') {
+        frontmatter[key] = value === 'true';
+        currentArray = null;
+      } else if (!isNaN(value) && value !== '') {
+        frontmatter[key] = Number(value);
+        currentArray = null;
+      } else {
+        frontmatter[key] = value;
+        currentArray = null;
+      }
+    }
+  }
+
+  return { frontmatter, content: content.trim() };
+}
+
+/**
+ * Extracts marked passage from content
+ * Looks for patterns like [Marked passage begins]...[Marked passage ends]
+ * or highlighted text markers
+ * @param {string} content - The markdown content
+ * @returns {string|null} - The extracted passage or null
+ */
+function extractMarkedPassage(content) {
+  // Try explicit markers
+  const markerRegex = /\[Marked passage begins?\]([\s\S]*?)\[Marked passage ends?\]/i;
+  const markerMatch = content.match(markerRegex);
+  if (markerMatch) {
+    return markerMatch[1].trim();
+  }
+
+  // Try highlight markers ==text==
+  const highlightRegex = /==([\s\S]+?)==/;
+  const highlightMatch = content.match(highlightRegex);
+  if (highlightMatch) {
+    return highlightMatch[1].trim();
+  }
+
+  // Try comic-marked blocks
+  const comicBlockRegex = /```comic\n([\s\S]*?)\n```/;
+  const comicMatch = content.match(comicBlockRegex);
+  if (comicMatch) {
+    return comicMatch[1].trim();
+  }
+
+  return null;
+}
+
+/**
+ * Parses Obsidian tags from content (e.g., #tag)
+ * @param {string} content - The markdown content
+ * @returns {string[]} - Array of tags
+ */
+function extractTags(content) {
+  const tagRegex = /#[\w-]+/g;
+  const matches = content.match(tagRegex) || [];
+  return [...new Set(matches)]; // Remove duplicates
+}
+
+/**
+ * Parses story prompts from frontmatter
+ * @param {Object} frontmatter - The frontmatter object
+ * @returns {Object|null} - Parsed story prompts or null
+ */
+function parseStoryPrompts(frontmatter) {
+  // Try structured story_prompts field
+  if (frontmatter.story_prompts || frontmatter.storyPrompts) {
+    const prompts = frontmatter.story_prompts || frontmatter.storyPrompts;
+    return {
+      characters: prompts.characters || [],
+      dominantEmotion: prompts.dominant_emotion || prompts.dominantEmotion || '',
+      visualMetaphor: prompts.visual_metaphor || prompts.visualMetaphor || '',
+      beforeContext: prompts.before_context || prompts.beforeContext || '',
+      afterContext: prompts.after_context || prompts.afterContext || '',
+    };
+  }
+
+  // Try individual fields
+  if (frontmatter.characters || frontmatter.emotion || frontmatter.metaphor) {
+    return {
+      characters: frontmatter.characters || [],
+      dominantEmotion: frontmatter.emotion || frontmatter.dominant_emotion || '',
+      visualMetaphor: frontmatter.metaphor || frontmatter.visual_metaphor || '',
+      beforeContext: frontmatter.before_context || frontmatter.context_before || '',
+      afterContext: frontmatter.after_context || frontmatter.context_after || '',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Parses an Obsidian markdown file into a JournalEntry
+ * @param {string} markdown - The markdown content
+ * @param {string} [filename] - Optional filename for generating ID
+ * @returns {Object} - JournalEntry object
+ */
+export function parseObsidianMarkdown(markdown, filename = null) {
+  const { frontmatter, content } = parseFrontmatter(markdown);
+
+  // Extract ID from filename or frontmatter
+  const id = frontmatter.id ||
+             filename?.replace(/\.md$/, '') ||
+             `entry-${Date.now()}`;
+
+  // Extract date
+  const date = frontmatter.date ||
+               frontmatter.created ||
+               new Date().toISOString();
+
+  // Extract themes
+  const themes = frontmatter.themes ||
+                 frontmatter.theme ? [frontmatter.theme] :
+                 [];
+
+  // Check if comic candidate
+  const comicCandidate = frontmatter.comic_candidate === true ||
+                         frontmatter.comicCandidate === true ||
+                         extractTags(content).includes('#to-comic');
+
+  // Extract tags
+  const tags = [
+    ...(frontmatter.tags || []),
+    ...extractTags(content),
+  ];
+
+  // Parse story prompts
+  const storyPrompts = parseStoryPrompts(frontmatter) || {
+    characters: [],
+    dominantEmotion: '',
+    visualMetaphor: '',
+    beforeContext: '',
+    afterContext: '',
+  };
+
+  // Extract marked passage
+  const excerpt = extractMarkedPassage(content) || '';
+
+  // Visual style
+  const visualStyle = frontmatter.visual_style ||
+                      frontmatter.visualStyle ||
+                      frontmatter.panel_style;
+
+  // Emotional intensity
+  const emotionalIntensity = frontmatter.emotional_intensity ||
+                             frontmatter.emotionalIntensity ||
+                             frontmatter.intensity;
+
+  return {
+    metadata: {
+      id,
+      date,
+      themes,
+      comicCandidate,
+      tags: [...new Set(tags)],
+      storyPrompts,
+      visualStyle,
+      emotionalIntensity,
+    },
+    content,
+    excerpt,
+  };
+}
+
+/**
+ * Parses a batch of Obsidian markdown files
+ * @param {Array<{filename: string, content: string}>} files - Array of files
+ * @returns {Object[]} - Array of JournalEntry objects
+ */
+export function parseBatch(files) {
+  return files.map(({ filename, content }) =>
+    parseObsidianMarkdown(content, filename)
+  );
+}
+
+/**
+ * Groups entries by theme
+ * @param {Object[]} entries - Array of JournalEntry objects
+ * @returns {Object} - Map of theme -> entries
+ */
+export function groupByTheme(entries) {
+  const themeMap = {};
+
+  for (const entry of entries) {
+    for (const theme of entry.metadata.themes) {
+      if (!themeMap[theme]) {
+        themeMap[theme] = [];
+      }
+      themeMap[theme].push(entry);
+    }
+  }
+
+  // Sort each theme's entries by date
+  for (const theme in themeMap) {
+    themeMap[theme].sort((a, b) =>
+      new Date(a.metadata.date) - new Date(b.metadata.date)
+    );
+  }
+
+  return themeMap;
+}
+
+/**
+ * Creates theme sequences from grouped entries
+ * @param {Object} themeMap - Map of theme -> entries
+ * @returns {Object[]} - Array of ThemeSequence objects
+ */
+export function createThemeSequences(themeMap) {
+  return Object.entries(themeMap).map(([theme, entries]) => ({
+    theme,
+    entryIds: entries.map(e => e.metadata.id),
+    entries: entries,
+    narrativeArc: `Evolution of ${theme} through ${entries.length} entries`,
+  }));
+}

--- a/src/journal/sceneGenerator.js
+++ b/src/journal/sceneGenerator.js
@@ -1,0 +1,400 @@
+/**
+ * Scene Generator - Transforms journal entries into comic-engine scenes
+ *
+ * Takes JournalEntry objects and generates React component configurations
+ * for Scene, SceneObject, and Panel components.
+ */
+
+/**
+ * Maps emotional intensity to visual parameters
+ * @param {number} intensity - 1-10 scale
+ * @returns {Object} - Visual parameters
+ */
+function getEmotionalVisuals(intensity = 5) {
+  // Low intensity: calm, distant, muted
+  if (intensity <= 3) {
+    return {
+      zPosition: -200,
+      parallaxFactor: 0.3,
+      rotation: [10, 0, 0],
+      opacity: 0.8,
+    };
+  }
+
+  // Medium intensity: present, engaged
+  if (intensity <= 6) {
+    return {
+      zPosition: 0,
+      parallaxFactor: 0.6,
+      rotation: [0, 0, 0],
+      opacity: 1,
+    };
+  }
+
+  // High intensity: immediate, overwhelming, close
+  return {
+    zPosition: 150,
+    parallaxFactor: 0.9,
+    rotation: [-5, 5, -3],
+    opacity: 1,
+  };
+}
+
+/**
+ * Maps emotions to panel variants and visual styles
+ * @param {string} emotion - The dominant emotion
+ * @returns {Object} - Panel configuration
+ */
+function getEmotionalPanelStyle(emotion) {
+  const emotionLower = emotion.toLowerCase();
+
+  // Nostalgic/memory
+  if (emotionLower.includes('nostalg') || emotionLower.includes('memory') || emotionLower.includes('past')) {
+    return {
+      variant: 'polaroid',
+      filter: 'sepia(30%) brightness(0.9)',
+    };
+  }
+
+  // Raw/intense/overwhelming
+  if (emotionLower.includes('raw') || emotionLower.includes('intense') || emotionLower.includes('overwhelm')) {
+    return {
+      variant: 'torn',
+      filter: 'contrast(1.2) saturate(1.3)',
+    };
+  }
+
+  // Digital/disconnected/modern
+  if (emotionLower.includes('disconnect') || emotionLower.includes('numb') || emotionLower.includes('digital')) {
+    return {
+      variant: 'monitor',
+      filter: 'brightness(0.95)',
+    };
+  }
+
+  // Clean/clear/present
+  if (emotionLower.includes('clear') || emotionLower.includes('present') || emotionLower.includes('peace')) {
+    return {
+      variant: 'borderless',
+      filter: 'none',
+    };
+  }
+
+  // Default
+  return {
+    variant: 'default',
+    filter: 'none',
+  };
+}
+
+/**
+ * Generates a scene configuration for a single journal entry
+ * @param {Object} entry - JournalEntry object
+ * @param {Object} options - Generation options
+ * @returns {Object} - Scene configuration
+ */
+export function generateSceneFromEntry(entry, options = {}) {
+  const {
+    metadata,
+    excerpt,
+  } = entry;
+
+  const {
+    centerPosition = [0, 0, 0],
+    includeBackground = true,
+  } = options;
+
+  const emotionalVisuals = getEmotionalVisuals(metadata.emotionalIntensity);
+  const panelStyle = metadata.visualStyle
+    ? { variant: metadata.visualStyle }
+    : getEmotionalPanelStyle(metadata.storyPrompts.dominantEmotion);
+
+  const sceneConfig = {
+    sceneProps: {
+      perspective: 1000,
+      parallaxIntensity: 1,
+      mouseInfluence: { x: 50, y: 30 },
+    },
+    objects: [],
+  };
+
+  // Background elements based on visual metaphor
+  if (includeBackground && metadata.storyPrompts.visualMetaphor) {
+    sceneConfig.objects.push({
+      type: 'background',
+      position: [-200, -100, -400],
+      rotation: [0, 0, 15],
+      parallaxFactor: 0.1,
+      content: {
+        type: 'metaphor',
+        text: metadata.storyPrompts.visualMetaphor,
+      },
+    });
+  }
+
+  // Main panel with excerpt
+  sceneConfig.objects.push({
+    type: 'panel',
+    position: [
+      centerPosition[0] + emotionalVisuals.zPosition * 0.1,
+      centerPosition[1],
+      centerPosition[2] + emotionalVisuals.zPosition,
+    ],
+    rotation: emotionalVisuals.rotation,
+    parallaxFactor: emotionalVisuals.parallaxFactor,
+    panel: {
+      width: 320,
+      height: 420,
+      variant: panelStyle.variant,
+      title: metadata.storyPrompts.dominantEmotion.toUpperCase(),
+      subtitle: new Date(metadata.date).toLocaleDateString(),
+      content: excerpt,
+      style: {
+        opacity: emotionalVisuals.opacity,
+        filter: panelStyle.filter,
+      },
+    },
+  });
+
+  // Character indicators (if specified)
+  if (metadata.storyPrompts.characters.length > 0) {
+    metadata.storyPrompts.characters.forEach((character, index) => {
+      const angle = (index / metadata.storyPrompts.characters.length) * 360;
+      const radius = 250;
+      const x = Math.cos(angle * Math.PI / 180) * radius;
+      const z = Math.sin(angle * Math.PI / 180) * radius - 200;
+
+      sceneConfig.objects.push({
+        type: 'character-marker',
+        position: [x, -50, z],
+        rotation: [0, -angle, 0],
+        parallaxFactor: 0.4,
+        content: {
+          character,
+        },
+      });
+    });
+  }
+
+  // Context indicators (before/after)
+  if (metadata.storyPrompts.beforeContext) {
+    sceneConfig.objects.push({
+      type: 'context',
+      position: [-300, 0, -100],
+      rotation: [0, 45, 0],
+      parallaxFactor: 0.5,
+      content: {
+        label: 'BEFORE',
+        text: metadata.storyPrompts.beforeContext,
+      },
+    });
+  }
+
+  if (metadata.storyPrompts.afterContext) {
+    sceneConfig.objects.push({
+      type: 'context',
+      position: [300, 0, -100],
+      rotation: [0, -45, 0],
+      parallaxFactor: 0.5,
+      content: {
+        label: 'AFTER',
+        text: metadata.storyPrompts.afterContext,
+      },
+    });
+  }
+
+  return sceneConfig;
+}
+
+/**
+ * Generates a theme-based narrative sequence scene
+ * @param {Object} themeSequence - ThemeSequence object with entries
+ * @param {Object} options - Generation options
+ * @returns {Object} - Scene configuration with multiple panels
+ */
+export function generateThemeSequenceScene(themeSequence, options = {}) {
+  const {
+    layout = 'timeline', // 'timeline' | 'spiral' | 'stack'
+  } = options;
+
+  const sceneConfig = {
+    sceneProps: {
+      perspective: 1200,
+      parallaxIntensity: 0.8,
+      mouseInfluence: { x: 60, y: 40 },
+      scrollEnabled: true,
+      scrollDepth: 500,
+    },
+    objects: [],
+    theme: themeSequence.theme,
+  };
+
+  const entries = themeSequence.entries || [];
+
+  if (layout === 'timeline') {
+    // Linear timeline layout - entries spread horizontally and in depth
+    entries.forEach((entry, index) => {
+      const spacing = 400;
+      const x = (index - entries.length / 2) * spacing;
+      const z = index * -50; // Slight depth progression
+      const y = Math.sin(index * 0.5) * 50; // Gentle wave
+
+      const emotionalVisuals = getEmotionalVisuals(entry.metadata.emotionalIntensity);
+      const panelStyle = getEmotionalPanelStyle(entry.metadata.storyPrompts.dominantEmotion);
+
+      sceneConfig.objects.push({
+        type: 'panel',
+        position: [x, y, z],
+        rotation: [0, 0, 0],
+        parallaxFactor: 0.6 - index * 0.05,
+        panel: {
+          width: 280,
+          height: 360,
+          variant: panelStyle.variant,
+          title: `${index + 1}. ${entry.metadata.storyPrompts.dominantEmotion}`,
+          subtitle: new Date(entry.metadata.date).toLocaleDateString(),
+          content: entry.excerpt,
+        },
+      });
+    });
+  } else if (layout === 'spiral') {
+    // Spiral layout - entries spiral inward/outward
+    entries.forEach((entry, index) => {
+      const angle = index * 137.5; // Golden angle for natural distribution
+      const radius = 200 + index * 80;
+      const x = Math.cos(angle * Math.PI / 180) * radius;
+      const z = Math.sin(angle * Math.PI / 180) * radius - 300;
+      const y = index * 30;
+
+      const panelStyle = getEmotionalPanelStyle(entry.metadata.storyPrompts.dominantEmotion);
+
+      sceneConfig.objects.push({
+        type: 'panel',
+        position: [x, y, z],
+        rotation: [0, -angle + 90, 0],
+        parallaxFactor: 0.5 + index * 0.05,
+        panel: {
+          width: 260,
+          height: 340,
+          variant: panelStyle.variant,
+          title: entry.metadata.storyPrompts.dominantEmotion,
+          subtitle: new Date(entry.metadata.date).toLocaleDateString(),
+          content: entry.excerpt,
+        },
+      });
+    });
+  } else if (layout === 'stack') {
+    // Stacked layout - entries stacked in Z depth
+    entries.forEach((entry, index) => {
+      const z = index * -150 - 200;
+      const emotionalVisuals = getEmotionalVisuals(entry.metadata.emotionalIntensity);
+      const panelStyle = getEmotionalPanelStyle(entry.metadata.storyPrompts.dominantEmotion);
+
+      sceneConfig.objects.push({
+        type: 'panel',
+        position: [0, 0, z],
+        rotation: [10, 0, 0],
+        parallaxFactor: 0.3 + index * 0.1,
+        panel: {
+          width: 320,
+          height: 420,
+          variant: panelStyle.variant,
+          title: entry.metadata.storyPrompts.dominantEmotion,
+          subtitle: new Date(entry.metadata.date).toLocaleDateString(),
+          content: entry.excerpt,
+        },
+      });
+    });
+  }
+
+  // Add theme title
+  sceneConfig.objects.push({
+    type: 'title',
+    position: [0, -200, 100],
+    rotation: [0, 0, 0],
+    parallaxFactor: 1.1,
+    content: {
+      text: themeSequence.theme.toUpperCase(),
+      subtitle: `${entries.length} entries`,
+    },
+  });
+
+  return sceneConfig;
+}
+
+/**
+ * Exports a scene configuration as a React component string
+ * @param {Object} sceneConfig - Scene configuration
+ * @returns {string} - React component code
+ */
+export function exportAsComponent(sceneConfig) {
+  const imports = `import React from 'react';
+import { Scene, SceneObject, Panel } from '../components/scene';
+import { useTheme } from '../theme/ThemeContext';`;
+
+  const componentName = `JournalScene${Date.now()}`;
+
+  let objectsCode = sceneConfig.objects.map((obj, index) => {
+    if (obj.type === 'panel') {
+      return `  <SceneObject
+    position={[${obj.position.join(', ')}]}
+    rotation={[${obj.rotation.join(', ')}]}
+    parallaxFactor={${obj.parallaxFactor}}
+  >
+    <Panel
+      width={${obj.panel.width}}
+      height={${obj.panel.height}}
+      variant="${obj.panel.variant}"
+      ${obj.panel.title ? `title="${obj.panel.title}"` : ''}
+      ${obj.panel.subtitle ? `subtitle="${obj.panel.subtitle}"` : ''}
+    >
+      <div style={{ padding: '20px', color: theme.colors.text }}>
+        {${JSON.stringify(obj.panel.content)}}
+      </div>
+    </Panel>
+  </SceneObject>`;
+    }
+
+    if (obj.type === 'title') {
+      return `  <SceneObject
+    position={[${obj.position.join(', ')}]}
+    rotation={[${obj.rotation.join(', ')}]}
+    parallaxFactor={${obj.parallaxFactor}}
+  >
+    <div style={{
+      fontFamily: theme.typography.fontDisplay,
+      fontSize: '48px',
+      color: theme.colors.primary,
+      textTransform: 'uppercase',
+      letterSpacing: '8px',
+    }}>
+      ${obj.content.text}
+    </div>
+  </SceneObject>`;
+    }
+
+    return '';
+  }).join('\n\n');
+
+  const component = `${imports}
+
+export function ${componentName}() {
+  const { theme } = useTheme();
+
+  return (
+    <Scene
+      perspective={${sceneConfig.sceneProps.perspective}}
+      parallaxIntensity={${sceneConfig.sceneProps.parallaxIntensity}}
+      mouseInfluence={{ x: ${sceneConfig.sceneProps.mouseInfluence.x}, y: ${sceneConfig.sceneProps.mouseInfluence.y} }}
+      ${sceneConfig.sceneProps.scrollEnabled ? 'scrollEnabled={true}' : ''}
+      ${sceneConfig.sceneProps.scrollDepth ? `scrollDepth={${sceneConfig.sceneProps.scrollDepth}}` : ''}
+    >
+${objectsCode}
+    </Scene>
+  );
+}
+
+export default ${componentName};`;
+
+  return component;
+}

--- a/src/journal/schema.js
+++ b/src/journal/schema.js
@@ -1,0 +1,151 @@
+/**
+ * Journal Entry Schema for Comic Integration
+ *
+ * This defines the data format for journal entries exported from Obsidian
+ * to be transformed into comic-engine scenes.
+ */
+
+/**
+ * @typedef {Object} JournalStoryPrompts
+ * @property {string[]} characters - Who's in this scene?
+ * @property {string} dominantEmotion - What's the dominant emotion?
+ * @property {string} visualMetaphor - What visual metaphor captures this moment?
+ * @property {string} beforeContext - What happened before?
+ * @property {string} afterContext - What happens after?
+ */
+
+/**
+ * @typedef {Object} JournalEntryMetadata
+ * @property {string} id - Unique identifier for the entry
+ * @property {string} date - ISO date string
+ * @property {string[]} themes - Themes explored in this entry (e.g., "healing", "growth", "loss")
+ * @property {boolean} comicCandidate - Whether this entry is marked for comic-ification
+ * @property {string[]} tags - Obsidian tags
+ * @property {JournalStoryPrompts} storyPrompts - Answers to story prompts
+ * @property {string} [visualStyle] - Optional visual style preference (e.g., "polaroid", "torn", "monitor")
+ * @property {number} [emotionalIntensity] - 1-10 scale for determining visual treatment
+ */
+
+/**
+ * @typedef {Object} JournalEntry
+ * @property {JournalEntryMetadata} metadata - Entry metadata and prompts
+ * @property {string} content - The journal entry markdown content
+ * @property {string} excerpt - Selected passage marked for comic-ification
+ */
+
+/**
+ * @typedef {Object} ThemeSequence
+ * @property {string} theme - The theme name
+ * @property {string[]} entryIds - Array of entry IDs exploring this theme (chronological)
+ * @property {string} narrativeArc - Description of how this theme evolves
+ */
+
+/**
+ * Validates a journal entry against the schema
+ * @param {any} entry - Entry to validate
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateJournalEntry(entry) {
+  const errors = [];
+
+  if (!entry.metadata) {
+    errors.push('Missing metadata');
+    return { valid: false, errors };
+  }
+
+  const { metadata } = entry;
+
+  if (!metadata.id || typeof metadata.id !== 'string') {
+    errors.push('metadata.id must be a string');
+  }
+
+  if (!metadata.date || typeof metadata.date !== 'string') {
+    errors.push('metadata.date must be an ISO date string');
+  }
+
+  if (!Array.isArray(metadata.themes) || metadata.themes.length === 0) {
+    errors.push('metadata.themes must be a non-empty array');
+  }
+
+  if (typeof metadata.comicCandidate !== 'boolean') {
+    errors.push('metadata.comicCandidate must be a boolean');
+  }
+
+  if (!metadata.storyPrompts) {
+    errors.push('metadata.storyPrompts is required');
+  } else {
+    const prompts = metadata.storyPrompts;
+    if (!Array.isArray(prompts.characters)) {
+      errors.push('storyPrompts.characters must be an array');
+    }
+    if (!prompts.dominantEmotion || typeof prompts.dominantEmotion !== 'string') {
+      errors.push('storyPrompts.dominantEmotion must be a string');
+    }
+    if (!prompts.visualMetaphor || typeof prompts.visualMetaphor !== 'string') {
+      errors.push('storyPrompts.visualMetaphor must be a string');
+    }
+  }
+
+  if (!entry.content || typeof entry.content !== 'string') {
+    errors.push('content must be a string');
+  }
+
+  if (!entry.excerpt || typeof entry.excerpt !== 'string') {
+    errors.push('excerpt must be a string (the marked passage)');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Example journal entry format
+ */
+export const exampleJournalEntry = {
+  metadata: {
+    id: '2025-01-15-morning',
+    date: '2025-01-15T09:30:00Z',
+    themes: ['healing', 'acceptance'],
+    comicCandidate: true,
+    tags: ['#journal', '#to-comic', '#breakthrough'],
+    storyPrompts: {
+      characters: ['myself', 'my younger self'],
+      dominantEmotion: 'bittersweet relief',
+      visualMetaphor: 'a door opening to light, but with shadows behind',
+      beforeContext: 'Years of carrying this weight alone',
+      afterContext: 'First steps toward letting it go',
+    },
+    visualStyle: 'torn',
+    emotionalIntensity: 7,
+  },
+  content: `# Morning Reflection
+
+Today something shifted. I've been holding onto this for so long...
+
+[Marked passage begins]
+I realized I don't have to carry all of this anymore. The weight I've been
+dragging through every day - it's not mine to carry. I can set it down.
+I can choose differently.
+[Marked passage ends]
+
+It feels both terrifying and freeing. Like standing at the edge of something new.`,
+  excerpt: `I realized I don't have to carry all of this anymore. The weight I've been
+dragging through every day - it's not mine to carry. I can set it down.
+I can choose differently.`,
+};
+
+/**
+ * Example theme sequence
+ */
+export const exampleThemeSequence = {
+  theme: 'healing',
+  entryIds: [
+    '2025-01-10-evening',
+    '2025-01-15-morning',
+    '2025-01-22-afternoon',
+    '2025-02-01-morning',
+  ],
+  narrativeArc: 'From recognizing the wound, through the first tentative steps of healing, to beginning to integrate the lessons',
+};

--- a/src/journal/templates/example-export.json
+++ b/src/journal/templates/example-export.json
@@ -1,0 +1,62 @@
+[
+  {
+    "metadata": {
+      "id": "2025-01-15-morning-reflection",
+      "date": "2025-01-15T09:30:00Z",
+      "themes": ["healing", "acceptance"],
+      "comicCandidate": true,
+      "tags": ["#journal", "#to-comic", "#breakthrough"],
+      "storyPrompts": {
+        "characters": ["myself", "my younger self"],
+        "dominantEmotion": "bittersweet relief",
+        "visualMetaphor": "a door opening to light, but with shadows behind",
+        "beforeContext": "Years of carrying this weight alone",
+        "afterContext": "First steps toward letting it go"
+      },
+      "visualStyle": "torn",
+      "emotionalIntensity": 7
+    },
+    "content": "# Morning Reflection\n\nToday something shifted. I've been holding onto this for so long...\n\n[Marked passage begins]\nI realized I don't have to carry all of this anymore. The weight I've been\ndragging through every day - it's not mine to carry. I can set it down.\nI can choose differently.\n[Marked passage ends]\n\nIt feels both terrifying and freeing. Like standing at the edge of something new.",
+    "excerpt": "I realized I don't have to carry all of this anymore. The weight I've been\ndragging through every day - it's not mine to carry. I can set it down.\nI can choose differently."
+  },
+  {
+    "metadata": {
+      "id": "2025-01-22-afternoon-walk",
+      "date": "2025-01-22T15:45:00Z",
+      "themes": ["healing", "nature", "presence"],
+      "comicCandidate": true,
+      "tags": ["#journal", "#to-comic", "#nature"],
+      "storyPrompts": {
+        "characters": ["myself"],
+        "dominantEmotion": "quiet peace",
+        "visualMetaphor": "roots growing deeper while branches reach skyward",
+        "beforeContext": "The decision to change",
+        "afterContext": "Slowly building new patterns"
+      },
+      "visualStyle": "borderless",
+      "emotionalIntensity": 4
+    },
+    "content": "# Afternoon Walk\n\nWalked through the park today. No agenda, just walking.\n\n==The trees don't struggle to grow. They just grow. Maybe I can learn from that - not forcing, just allowing.==\n\nSmall steps. That's all it takes.",
+    "excerpt": "The trees don't struggle to grow. They just grow. Maybe I can learn from that - not forcing, just allowing."
+  },
+  {
+    "metadata": {
+      "id": "2025-02-01-morning-setback",
+      "date": "2025-02-01T08:00:00Z",
+      "themes": ["healing", "resilience", "growth"],
+      "comicCandidate": true,
+      "tags": ["#journal", "#to-comic", "#setback"],
+      "storyPrompts": {
+        "characters": ["myself", "the old patterns"],
+        "dominantEmotion": "frustrated determination",
+        "visualMetaphor": "climbing a mountain, slipping back, but keeping the summit in sight",
+        "beforeContext": "Making progress, feeling hopeful",
+        "afterContext": "Understanding that healing isn't linear"
+      },
+      "visualStyle": "default",
+      "emotionalIntensity": 6
+    },
+    "content": "# Morning - After the Setback\n\nFell back into old patterns yesterday. Felt like I'd lost all progress.\n\n```comic\nBut today I see it differently. Every time I choose again, even after falling,\nI'm building the muscle of resilience. The mountain doesn't judge how many times\nI slip. It just is. And I keep climbing.\n```\n\nThis is the work. Not perfection. Progress.",
+    "excerpt": "Every time I choose again, even after falling, I'm building the muscle of resilience. The mountain doesn't judge how many times I slip. It just is. And I keep climbing."
+  }
+]

--- a/src/journal/templates/obsidian-comic-template.md
+++ b/src/journal/templates/obsidian-comic-template.md
@@ -1,0 +1,62 @@
+---
+comic_candidate: true
+date: {{date}}
+themes:
+  -
+tags:
+  - journal
+  - to-comic
+visual_style: default
+emotional_intensity: 5
+
+# Story Prompts
+characters:
+  -
+dominant_emotion:
+visual_metaphor:
+before_context:
+after_context:
+---
+
+# {{title}}
+
+<!-- Write your journal entry here -->
+
+<!-- Mark the passage you want to turn into a comic panel -->
+[Marked passage begins]
+
+[Marked passage ends]
+
+<!-- Alternative: Use highlight syntax -->
+==Your highlighted passage here==
+
+<!-- Alternative: Use comic code block -->
+```comic
+Your passage in a code block
+```
+
+---
+
+## Comic Story Prompts
+
+Fill these in when you're ready to transform this entry into a comic:
+
+**Who's in this scene?**
+- Add characters to the frontmatter `characters` array
+
+**What's the dominant emotion?**
+Update the `dominant_emotion` field in frontmatter
+
+**What visual metaphor captures this moment?**
+Update the `visual_metaphor` field in frontmatter
+
+**What's the before/after context?**
+Update `before_context` and `after_context` fields in frontmatter
+
+---
+
+## Tags for Comic Integration
+
+- `#to-comic` - Mark this entry for comic-ification
+- `#journal` - Standard journal tag
+- Add theme tags like `#healing`, `#growth`, `#loss`, etc.

--- a/src/journal/useJournalEntries.js
+++ b/src/journal/useJournalEntries.js
@@ -1,0 +1,187 @@
+/**
+ * React Hook for managing journal entries
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { parseObsidianMarkdown, groupByTheme, createThemeSequences } from './parser.js';
+import { validateJournalEntry } from './schema.js';
+
+/**
+ * Hook for loading and managing journal entries
+ * @param {Object} options - Configuration options
+ * @returns {Object} - Journal entries state and methods
+ */
+export function useJournalEntries(options = {}) {
+  const {
+    autoLoad = false,
+    initialEntries = [],
+  } = options;
+
+  const [entries, setEntries] = useState(initialEntries);
+  const [themes, setThemes] = useState({});
+  const [sequences, setSequences] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Update themes and sequences when entries change
+  useEffect(() => {
+    if (entries.length === 0) {
+      setThemes({});
+      setSequences([]);
+      return;
+    }
+
+    const themeMap = groupByTheme(entries);
+    setThemes(themeMap);
+    setSequences(createThemeSequences(themeMap));
+  }, [entries]);
+
+  /**
+   * Load entries from JSON file or API
+   * @param {string} source - URL or file path
+   */
+  const loadFromSource = useCallback(async (source) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(source);
+      if (!response.ok) {
+        throw new Error(`Failed to load: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      const loadedEntries = Array.isArray(data) ? data : [data];
+
+      // Validate entries
+      const validEntries = [];
+      const errors = [];
+
+      for (const entry of loadedEntries) {
+        const validation = validateJournalEntry(entry);
+        if (validation.valid) {
+          validEntries.push(entry);
+        } else {
+          errors.push({ entry, errors: validation.errors });
+        }
+      }
+
+      if (errors.length > 0) {
+        console.warn('Some entries failed validation:', errors);
+      }
+
+      setEntries(validEntries);
+      setLoading(false);
+    } catch (err) {
+      setError(err.message);
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * Parse markdown files into entries
+   * @param {Array<{filename: string, content: string}>} files
+   */
+  const parseMarkdownFiles = useCallback((files) => {
+    const parsedEntries = files.map(({ filename, content }) =>
+      parseObsidianMarkdown(content, filename)
+    );
+
+    setEntries(prevEntries => [...prevEntries, ...parsedEntries]);
+  }, []);
+
+  /**
+   * Add a single entry
+   * @param {Object} entry - JournalEntry object
+   */
+  const addEntry = useCallback((entry) => {
+    const validation = validateJournalEntry(entry);
+    if (!validation.valid) {
+      setError(`Invalid entry: ${validation.errors.join(', ')}`);
+      return false;
+    }
+
+    setEntries(prevEntries => [...prevEntries, entry]);
+    return true;
+  }, []);
+
+  /**
+   * Remove an entry by ID
+   * @param {string} id - Entry ID
+   */
+  const removeEntry = useCallback((id) => {
+    setEntries(prevEntries => prevEntries.filter(e => e.metadata.id !== id));
+  }, []);
+
+  /**
+   * Update an entry
+   * @param {string} id - Entry ID
+   * @param {Object} updates - Partial entry updates
+   */
+  const updateEntry = useCallback((id, updates) => {
+    setEntries(prevEntries =>
+      prevEntries.map(entry =>
+        entry.metadata.id === id
+          ? { ...entry, ...updates, metadata: { ...entry.metadata, ...updates.metadata } }
+          : entry
+      )
+    );
+  }, []);
+
+  /**
+   * Filter entries by theme
+   * @param {string} theme - Theme name
+   * @returns {Object[]} - Filtered entries
+   */
+  const getByTheme = useCallback((theme) => {
+    return themes[theme] || [];
+  }, [themes]);
+
+  /**
+   * Get entries marked as comic candidates
+   * @returns {Object[]} - Comic candidate entries
+   */
+  const getComicCandidates = useCallback(() => {
+    return entries.filter(e => e.metadata.comicCandidate);
+  }, [entries]);
+
+  /**
+   * Filter entries by date range
+   * @param {Date} startDate
+   * @param {Date} endDate
+   * @returns {Object[]} - Filtered entries
+   */
+  const getByDateRange = useCallback((startDate, endDate) => {
+    return entries.filter(entry => {
+      const date = new Date(entry.metadata.date);
+      return date >= startDate && date <= endDate;
+    });
+  }, [entries]);
+
+  /**
+   * Clear all entries
+   */
+  const clear = useCallback(() => {
+    setEntries([]);
+    setError(null);
+  }, []);
+
+  return {
+    entries,
+    themes,
+    sequences,
+    loading,
+    error,
+
+    // Methods
+    loadFromSource,
+    parseMarkdownFiles,
+    addEntry,
+    removeEntry,
+    updateEntry,
+    getByTheme,
+    getComicCandidates,
+    getByDateRange,
+    clear,
+  };
+}

--- a/src/pages/JournalExample.jsx
+++ b/src/pages/JournalExample.jsx
@@ -1,0 +1,298 @@
+import React, { useState, useEffect } from 'react';
+import { Scene, SceneObject, Panel } from '../components/scene';
+import { useTheme } from '../theme/ThemeContext';
+import { useJournalEntries, generateThemeSequenceScene } from '../journal';
+
+/**
+ * JournalExample - Demonstrates journal-to-comic integration
+ *
+ * This page shows how to:
+ * 1. Load journal entries from JSON
+ * 2. Generate scenes from theme sequences
+ * 3. Navigate between different themes
+ */
+export function JournalExample() {
+  const { theme } = useTheme();
+  const {
+    sequences,
+    loading,
+    error,
+    loadFromSource,
+  } = useJournalEntries();
+
+  const [selectedTheme, setSelectedTheme] = useState(null);
+  const [sceneConfig, setSceneConfig] = useState(null);
+
+  // Load example data on mount
+  useEffect(() => {
+    loadFromSource('/src/journal/templates/example-export.json').catch(err => {
+      console.error('Failed to load example data:', err);
+    });
+  }, [loadFromSource]);
+
+  // Generate scene when theme is selected
+  useEffect(() => {
+    if (selectedTheme) {
+      const sequence = sequences.find(s => s.theme === selectedTheme);
+      if (sequence) {
+        const config = generateThemeSequenceScene(sequence, { layout: 'timeline' });
+        setSceneConfig(config);
+      }
+    }
+  }, [selectedTheme, sequences]);
+
+  // Auto-select first theme when sequences load
+  useEffect(() => {
+    if (sequences.length > 0 && !selectedTheme) {
+      setSelectedTheme(sequences[0].theme);
+    }
+  }, [sequences, selectedTheme]);
+
+  if (loading) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        color: theme.colors.text,
+        fontFamily: theme.typography.fontBody,
+      }}>
+        Loading journal entries...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        color: theme.colors.error || '#ff4444',
+        fontFamily: theme.typography.fontBody,
+      }}>
+        Error: {error}
+      </div>
+    );
+  }
+
+  if (!sceneConfig) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        color: theme.colors.textMuted,
+        fontFamily: theme.typography.fontBody,
+      }}>
+        No journal entries found. Place example-export.json in /public
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Theme selector */}
+      <div style={{
+        position: 'fixed',
+        top: '20px',
+        right: '20px',
+        zIndex: 1000,
+        background: 'rgba(0,0,0,0.8)',
+        backdropFilter: 'blur(10px)',
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: '8px',
+        padding: '16px',
+        fontFamily: theme.typography.fontBody,
+      }}>
+        <h3 style={{
+          color: theme.colors.primary,
+          margin: '0 0 12px 0',
+          fontSize: '12px',
+          letterSpacing: '2px',
+          textTransform: 'uppercase',
+        }}>
+          Themes
+        </h3>
+        {sequences.map(seq => (
+          <button
+            key={seq.theme}
+            onClick={() => setSelectedTheme(seq.theme)}
+            style={{
+              display: 'block',
+              width: '100%',
+              padding: '8px 12px',
+              margin: '4px 0',
+              background: selectedTheme === seq.theme
+                ? theme.colors.primary
+                : 'rgba(255,255,255,0.1)',
+              color: selectedTheme === seq.theme
+                ? '#000'
+                : theme.colors.text,
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '11px',
+              textAlign: 'left',
+              textTransform: 'capitalize',
+              transition: 'all 0.2s',
+            }}
+          >
+            {seq.theme} ({seq.entryIds.length})
+          </button>
+        ))}
+      </div>
+
+      {/* Generated scene */}
+      <Scene {...sceneConfig.sceneProps}>
+        {sceneConfig.objects.map((obj, index) => {
+          if (obj.type === 'panel') {
+            return (
+              <SceneObject
+                key={`panel-${index}`}
+                position={obj.position}
+                rotation={obj.rotation}
+                parallaxFactor={obj.parallaxFactor}
+              >
+                <Panel
+                  width={obj.panel.width}
+                  height={obj.panel.height}
+                  variant={obj.panel.variant}
+                  title={obj.panel.title}
+                  subtitle={obj.panel.subtitle}
+                  style={obj.panel.style}
+                >
+                  <div style={{
+                    padding: '20px',
+                    color: theme.colors.text,
+                    fontSize: '13px',
+                    lineHeight: '1.6',
+                    fontFamily: theme.typography.fontNarrative,
+                  }}>
+                    {obj.panel.content}
+                  </div>
+                </Panel>
+              </SceneObject>
+            );
+          }
+
+          if (obj.type === 'title') {
+            return (
+              <SceneObject
+                key={`title-${index}`}
+                position={obj.position}
+                rotation={obj.rotation}
+                parallaxFactor={obj.parallaxFactor}
+                interactive={false}
+              >
+                <div style={{
+                  fontFamily: theme.typography.fontDisplay,
+                  fontSize: '64px',
+                  color: theme.colors.primary,
+                  textTransform: 'uppercase',
+                  letterSpacing: '12px',
+                  textShadow: `0 0 40px ${theme.colors.shadow}`,
+                  textAlign: 'center',
+                }}>
+                  {obj.content.text}
+                  {obj.content.subtitle && (
+                    <div style={{
+                      fontSize: '16px',
+                      color: theme.colors.textMuted,
+                      letterSpacing: '4px',
+                      marginTop: '20px',
+                    }}>
+                      {obj.content.subtitle}
+                    </div>
+                  )}
+                </div>
+              </SceneObject>
+            );
+          }
+
+          if (obj.type === 'context') {
+            return (
+              <SceneObject
+                key={`context-${index}`}
+                position={obj.position}
+                rotation={obj.rotation}
+                parallaxFactor={obj.parallaxFactor}
+              >
+                <div style={{
+                  width: '200px',
+                  padding: '16px',
+                  background: 'rgba(0,0,0,0.6)',
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: '4px',
+                  fontFamily: theme.typography.fontBody,
+                }}>
+                  <div style={{
+                    fontSize: '10px',
+                    color: theme.colors.secondary,
+                    letterSpacing: '2px',
+                    marginBottom: '8px',
+                  }}>
+                    {obj.content.label}
+                  </div>
+                  <div style={{
+                    fontSize: '11px',
+                    color: theme.colors.textMuted,
+                    lineHeight: '1.4',
+                  }}>
+                    {obj.content.text}
+                  </div>
+                </div>
+              </SceneObject>
+            );
+          }
+
+          return null;
+        })}
+      </Scene>
+
+      {/* Info panel */}
+      <div style={{
+        position: 'fixed',
+        bottom: '20px',
+        left: '20px',
+        background: 'rgba(0,0,0,0.8)',
+        backdropFilter: 'blur(10px)',
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: '8px',
+        padding: '16px',
+        maxWidth: '300px',
+        fontFamily: theme.typography.fontBody,
+        zIndex: 1000,
+      }}>
+        <h3 style={{
+          color: theme.colors.primary,
+          margin: '0 0 8px 0',
+          fontSize: '12px',
+          letterSpacing: '2px',
+        }}>
+          JOURNAL INTEGRATION
+        </h3>
+        <p style={{
+          color: theme.colors.textMuted,
+          margin: 0,
+          fontSize: '10px',
+          lineHeight: 1.5,
+        }}>
+          Theme: <strong style={{ color: theme.colors.text }}>{selectedTheme}</strong>
+          <br />
+          Entries: <strong style={{ color: theme.colors.text }}>
+            {sequences.find(s => s.theme === selectedTheme)?.entryIds.length || 0}
+          </strong>
+          <br />
+          <br />
+          {sceneConfig.sceneProps.scrollEnabled && '↓ Scroll to explore timeline'}
+        </p>
+      </div>
+    </>
+  );
+}
+
+export default JournalExample;


### PR DESCRIPTION
## Summary

Implements comprehensive journal-to-comic system that connects comic-engine with Obsidian journal entries to visualize memories and themes as 3D parallax comic panels.

## Features

- ✅ Obsidian markdown parser with frontmatter support
- ✅ Story prompts system (characters, emotions, metaphors, context)
- ✅ Theme-based grouping and narrative sequences
- ✅ Scene generator with emotional intensity mapping
- ✅ Multiple layout algorithms (timeline, spiral, stack)
- ✅ Visual style variants based on emotion
- ✅ React hook for entry management
- ✅ Example implementation and templates

## Implementation

**Core Modules** (`src/journal/`):
- `schema.js` - Data format definitions
- `parser.js` - Markdown parsing with 3 extraction methods
- `sceneGenerator.js` - Scene configuration generation
- `useJournalEntries.js` - React hook
- `index.js` - Main exports

**Templates**:
- Obsidian template with story prompts
- Example JSON export with 3 entries

**Example**:
- `src/pages/JournalExample.jsx` - Full working demo

**Documentation**:
- Comprehensive README with API reference and guides

Supports exploring themes across multiple journal entries, with automatic visual treatment based on emotional intensity and dominant emotions.

Fixes #1

----
🤖 Generated with [Claude Code](https://claude.ai/code)