### PR TITLE
feat: cutout fill mode options (blur and solid color)

### DIFF
--- a/src/utils/depth/pipeline.js
+++ b/src/utils/depth/pipeline.js
@@ -6,7 +6,7 @@
  */
 
 import { estimateDepth, visualizeDepthMap } from './depthEstimation.js';
-import { quantizeDepth, depthToZPosition } from './quantization.js';
+import { quantizeDepth } from './quantization.js';
 import { segmentLayers } from './segmentation.js';
 
 /**
@@ -81,6 +81,8 @@ export async function processPhotoToLayers(image, options = {}) {
         depth: obj.depth,
         zPosition,
         imageUrl: obj.imageData,
+        fillMaskUrl: obj.fillMaskUrl,
+        blurFillUrl: obj.blurFillImageData,
         bounds: obj.bounds,
         componentCount: obj.componentCount,
 
@@ -153,7 +155,7 @@ function calculateParallaxFactor(depth) {
  * @returns {Array<SceneLayer>} Layers with SceneObject props
  */
 export function getSceneLayers(result) {
-  return result.layers.map(layer => ({
+  return result.layers.map((layer) => ({
     id: layer.id,
     name: layer.name,
     imageUrl: layer.imageUrl,


### PR DESCRIPTION
## Summary
- Replace blur-fill slider with checkbox-driven fill mode selection (None / Blur / Solid Color)
- Segmentation now always outputs sharp layers + fill masks alongside optional blur-filled versions
- Solid color mode uses CSS `mask-image` with `theme.colors.background`, responding to theme changes instantly without reprocessing

## Changes
- **segmentation.js**: Always output sharp image + `fillMaskUrl` per layer; optionally compute blur-filled image. New `generateFillMask()` helper.
- **pipeline.js**: Thread `fillMaskUrl` and `blurFillUrl` through to layer output. Remove unused `depthToZPosition` import.
- **DepthSegmentationDemo.jsx**: Replace blur slider with fill mode checkboxes. Render solid color fill via CSS mask-image for theme-reactive behavior.

## Test plan
- [ ] Upload image, process with Blur Fill checked — layers show blurred fill behind cutouts
- [ ] Toggle to Solid Color — fill switches to theme background color instantly (no reprocessing)
- [ ] Switch theme while in Solid Color mode — fill color updates immediately
- [ ] Toggle to None — cutouts are transparent
- [ ] Adjust blur radius slider, reprocess — blur intensity changes