### PR TITLE
feat: preserve true layer depth from original depth map

### DIFF
--- a/src/utils/depth/__tests__/pipeline.test.js
+++ b/src/utils/depth/__tests__/pipeline.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fixedStepArrangement,
+  fillRangeArrangement,
+  depthProportionalArrangement,
+} from '../pipeline.js';
+
+describe('fixedStepArrangement', () => {
+  it('returns evenly spaced positions starting from default start', () => {
+    expect(fixedStepArrangement(3)).toEqual([-400, -350, -300]);
+  });
+
+  it('accepts depths in opts without breaking', () => {
+    const depths = [0.1, 0.5, 0.9];
+    expect(fixedStepArrangement(3, { depths })).toEqual([-400, -350, -300]);
+  });
+});
+
+describe('fillRangeArrangement', () => {
+  it('fills the entire z-range evenly', () => {
+    expect(fillRangeArrangement(3)).toEqual([-400, -100, 200]);
+  });
+
+  it('returns [far] for count <= 1', () => {
+    expect(fillRangeArrangement(1)).toEqual([-400]);
+    expect(fillRangeArrangement(0)).toEqual([-400]);
+  });
+
+  it('accepts depths in opts without breaking', () => {
+    const depths = [0.1, 0.5, 0.9];
+    expect(fillRangeArrangement(3, { depths })).toEqual([-400, -100, 200]);
+  });
+});
+
+describe('depthProportionalArrangement', () => {
+  it('maps evenly-spread depths to full z-range', () => {
+    const result = depthProportionalArrangement(3, {
+      depths: [0, 0.5, 1],
+      far: -400,
+      near: 200,
+    });
+    expect(result).toEqual([-400, -100, 200]);
+  });
+
+  it('maps uneven depths proportionally', () => {
+    const result = depthProportionalArrangement(3, {
+      depths: [0.1, 0.5, 0.9],
+      far: -400,
+      near: 200,
+    });
+    // z = far + depth * (near - far) = -400 + depth * 600
+    // depth=0.1 → -400 + 60 = -340
+    // depth=0.5 → -400 + 300 = -100
+    // depth=0.9 → -400 + 540 = 140
+    expect(result).toEqual([-340, -100, 140]);
+  });
+
+  it('maps depth=0 to far and depth=1 to near', () => {
+    const result = depthProportionalArrangement(2, {
+      depths: [0, 1],
+      far: -400,
+      near: 200,
+    });
+    expect(result).toEqual([-400, 200]);
+  });
+
+  it('returns [] for count=0', () => {
+    expect(depthProportionalArrangement(0, { depths: [], far: -400, near: 200 })).toEqual([]);
+  });
+
+  it('returns [far] for a single layer at depth=0', () => {
+    const result = depthProportionalArrangement(1, { depths: [0], far: -400, near: 200 });
+    expect(result).toEqual([-400]);
+  });
+
+  it('returns [near] for a single layer at depth=1', () => {
+    const result = depthProportionalArrangement(1, { depths: [1], far: -400, near: 200 });
+    expect(result).toEqual([200]);
+  });
+
+  it('places all layers at same z when all depths are equal', () => {
+    const result = depthProportionalArrangement(3, {
+      depths: [0.5, 0.5, 0.5],
+      far: -400,
+      near: 200,
+    });
+    expect(result).toEqual([-100, -100, -100]);
+  });
+
+  it('falls back to fillRangeArrangement when depths is not provided', () => {
+    const result = depthProportionalArrangement(3, { far: -400, near: 200 });
+    expect(result).toEqual([-400, -100, 200]);
+  });
+
+  it('falls back to fillRangeArrangement when depths length does not match count', () => {
+    const result = depthProportionalArrangement(3, {
+      depths: [0.1, 0.9],
+      far: -400,
+      near: 200,
+    });
+    expect(result).toEqual([-400, -100, 200]);
+  });
+
+  it('uses default far=-400 and near=200 when not specified', () => {
+    const result = depthProportionalArrangement(2, { depths: [0, 1] });
+    expect(result).toEqual([-400, 200]);
+  });
+
+  it('works with custom far and near values', () => {
+    const result = depthProportionalArrangement(3, {
+      depths: [0, 0.5, 1],
+      far: -100,
+      near: 100,
+    });
+    expect(result).toEqual([-100, 0, 100]);
+  });
+});

--- a/src/utils/depth/index.js
+++ b/src/utils/depth/index.js
@@ -12,4 +12,5 @@ export {
   getSceneLayers,
   fixedStepArrangement,
   fillRangeArrangement,
+  depthProportionalArrangement,
 } from './pipeline.js';

--- a/src/utils/depth/pipeline.js
+++ b/src/utils/depth/pipeline.js
@@ -70,7 +70,8 @@ export async function processPhotoToLayers(image, options = {}) {
     // Step 4: Export format conversion
     if (onProgress) onProgress('export', 0);
     const arrange = layerArrangement || fixedStepArrangement;
-    const zPositions = arrange(layerObjects.length);
+    const depths = layerObjects.map((obj) => obj.depth);
+    const zPositions = arrange(layerObjects.length, { depths });
 
     result.layers = layerObjects.map((obj, index) => {
       const zPosition = zPositions[index];
@@ -132,6 +133,29 @@ export function fillRangeArrangement(count, { far = -400, near = 200 } = {}) {
   if (count <= 1) return [far];
   const step = (near - far) / (count - 1);
   return Array.from({ length: count }, (_, i) => far + i * step);
+}
+
+/**
+ * Arrange layers proportionally to their actual depth values.
+ * Layers that are far apart in depth space are far apart in z-space.
+ * depths=[0,0.5,1], far=-400, near=200 → [-400, -100, 200]
+ * depths=[0.1,0.5,0.9], far=-400, near=200 → [-340, -100, 140]
+ *
+ * Falls back to fillRangeArrangement if depths is not provided or has wrong length.
+ *
+ * @param {number} count - Number of layers
+ * @param {Object} opts
+ * @param {number[]} opts.depths - Normalized depth values [0,1], one per layer
+ * @param {number} opts.far  - Z mapped to depth=0 (farthest, default -400)
+ * @param {number} opts.near - Z mapped to depth=1 (nearest, default 200)
+ * @returns {number[]} Z positions, one per layer
+ */
+export function depthProportionalArrangement(count, { depths, far = -400, near = 200 } = {}) {
+  if (count === 0) return [];
+  if (!depths || depths.length !== count) {
+    return fillRangeArrangement(count, { far, near });
+  }
+  return depths.map((depth) => far + depth * (near - far));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Preserves the original depth values from the depth estimation when creating layers
- Implements depth-proportional arrangement instead of uniform spacing

Closes #20