### PR TITLE
feat: add .local/ to .gitignore for persistent local scene storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ chrome-user-data
 *.swo
 /tmp
 
+# Local persistent storage (user-created scenes, not tracked by git)
+.local/
+
 # Python backend
 __pycache__/
 *.egg-info/


### PR DESCRIPTION
Add `.local/` directory to `.gitignore` to serve as local-only storage for user-created scene pages. This directory stores scene images and metadata that persist across rebuilds without being tracked by git.

Closes #40

Generated with [Claude Code](https://claude.ai/code)