### PR TITLE
fix: handle video/* MIME types in dataUrlExtension (#77)

### DIFF
--- a/vite-plugin-scene-exporter.js
+++ b/vite-plugin-scene-exporter.js
@@ -127,11 +127,18 @@ function dataUrlToBuffer(dataUrl) {
 }
 
 function dataUrlExtension(dataUrl) {
-  const match = dataUrl.match(/^data:image\/([a-z]+);base64,/);
+  const match = dataUrl.match(/^data:(image|video)\/([a-z0-9]+);base64,/);
   if (!match) return 'png';
-  const mime = match[1];
-  if (mime === 'jpeg') return 'jpg';
-  return mime;
+  const type = match[1];
+  const subtype = match[2];
+  if (type === 'image') {
+    if (subtype === 'jpeg') return 'jpg';
+    return subtype;
+  }
+  // video/*
+  if (subtype === 'quicktime') return 'mov';
+  if (subtype === 'mp4' || subtype === 'webm' || subtype === 'ogg') return subtype;
+  return subtype;
 }
 
 function readBody(req) {


### PR DESCRIPTION
## Summary
- `dataUrlExtension()` in `vite-plugin-scene-exporter.js` only matched `image/*` data URLs, causing video uploads to fall through to the `'png'` default — so uploaded videos were saved with a `.png` extension and rendered corrupt.
- The regex now matches both `image/*` and `video/*` MIME types, and maps common video subtypes (`webm`, `mp4`, `ogg`, `quicktime` → `mov`) to the correct file extensions.
- Existing image behavior (`png`, `jpg`, `gif`, `webp`, `jpeg` → `jpg`) is preserved.

## Test plan
- [ ] Upload a `.webm` video via the Video Overlay card and confirm it is written with a `.webm` extension (not `.png`).
- [ ] Upload a `.mp4` video and confirm the saved file has a `.mp4` extension and plays back correctly.
- [ ] Upload a PNG / JPG image and confirm extensions remain `.png` / `.jpg` (regression check).
- [ ] `npm run lint` and `npm test` pass on main-level checks (no new errors introduced by this change).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)