### PR TITLE
feat: increase scroll speed (#88)

### DIFF
--- a/src/hooks/useZScroll.js
+++ b/src/hooks/useZScroll.js
@@ -117,7 +117,7 @@ export function useZScroll({
         snapTimeoutRef.current = null;
       }
 
-      const next = clamp(scrollZRef.current + e.deltaY * 0.5);
+      const next = clamp(scrollZRef.current + e.deltaY * 0.875);
       scrollZRef.current = next;
       setScrollZ(next);
 


### PR DESCRIPTION
## Summary

Increases Z-depth scroll speed so users move through slides/layers faster on wheel input.

## Change

- **File:** `src/hooks/useZScroll.js`
- **Constant:** wheel `deltaY` multiplier inside the `handleWheel` listener (line 120)
- **Old value:** `0.5`
- **New value:** `0.875` (1.75x increase — conservative bump within the 1.5x–2x range)

This is the single principal scroll-speed constant in the codebase. No other `SCROLL_SPEED`, `scrollMultiplier`, or `deltaY`-scaling constants were found, so nothing else required follow-up.

Related values (NOT changed, for reference):
- `animateTo` lerp factor `0.12` (smoothing, not input speed)
- `snapThreshold` default `80` (snap distance)
- `scrollDepth` defaults per page (total Z range)

## Verification

- `npm run build` — passes
- `npm test -- useZScroll` — 19/19 tests pass
- `npm test` — pre-existing failures in `ComicBookReader`, `gcsStorage`, `gcsStorageWrite` (unrelated to scroll; not introduced by this change)
- `npm run lint` — pre-existing errors in `ClockworkShell.jsx` and `Scene.jsx` (unrelated; not introduced by this change)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)