### PR TITLE
fix: surface upload errors in VideoCardModal (#78)

### DIFF
--- a/src/components/scene/InsertModals.jsx
+++ b/src/components/scene/InsertModals.jsx
@@ -502,11 +502,13 @@ export function VideoCardModal({ onConfirm, onCancel }) {
   const [videoUrl, setVideoUrl] = useState('');
   const [width, setWidth] = useState(400);
   const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleFileUpload = useCallback(async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
+    setError(null);
     const reader = new FileReader();
     reader.onload = async () => {
       try {
@@ -515,11 +517,15 @@ export function VideoCardModal({ onConfirm, onCancel }) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ imageUrl: reader.result }),
         });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.error || 'Upload failed');
+        }
         const data = await resp.json();
         if (data.url) setVideoUrl(data.url);
         else if (data.path) setVideoUrl(data.path);
       } catch (err) {
-        console.error('Upload failed:', err);
+        setError(err.message);
       }
       setUploading(false);
     };
@@ -590,6 +596,7 @@ export function VideoCardModal({ onConfirm, onCancel }) {
           WebM with VP9 alpha supports transparent backgrounds. Video will autoplay, loop, and be
           muted.
         </div>
+        {error && <div style={{ color: '#f55', fontSize: '11px' }}>{error}</div>}
       </div>
     </ModalBase>
   );


### PR DESCRIPTION
## Summary
- `VideoCardModal` in `src/components/scene/InsertModals.jsx` now checks `resp.ok` on `/_dev/assets` upload, matching the pattern used by `MemoryCardModal` and `ImageCardModal`.
- On failure, stores the server-provided error message in `error` state and renders it in red next to the upload field.
- Failed video uploads no longer fall through to `setVideoUrl(undefined)` with no user feedback.

Closes #78

## Test plan
- [ ] Trigger a failing upload (e.g. oversize/invalid video) and confirm the error surfaces in the modal
- [ ] Confirm successful upload path still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)