### PR TITLE
fix: await save before deselect in DynamicScenePage (#82)

### DIFF
--- a/src/hooks/useSceneLoader.js
+++ b/src/hooks/useSceneLoader.js
@@ -80,8 +80,8 @@ export function useSceneLoader(slug, source, options = {}) {
   const save = useCallback(
     async ({ groupOffset, groupOffsets, objects: newObjects = [], replaceObjects = false }) => {
       if (resolvedSource !== 'local') {
-        // GCS backend is read-only
-        return;
+        // GCS backend is read-only — treat as a no-op success so callers don't block.
+        return true;
       }
       try {
         const existingObjects = scene?.objects || [];
@@ -94,12 +94,14 @@ export function useSceneLoader(slug, source, options = {}) {
         });
         if (!res.ok) {
           console.error('Failed to save scene positions:', await res.text());
-        } else {
-          // Update local state so UI reflects saved data immediately
-          setScene((prev) => (prev ? { ...prev, objects: allObjects } : prev));
+          return false;
         }
+        // Update local state so UI reflects saved data immediately
+        setScene((prev) => (prev ? { ...prev, objects: allObjects } : prev));
+        return true;
       } catch (err) {
         console.error('Failed to save scene positions:', err);
+        return false;
       }
     },
     [slug, scene, resolvedSource],

--- a/src/pages/DynamicScenePage.jsx
+++ b/src/pages/DynamicScenePage.jsx
@@ -95,6 +95,8 @@ export function DynamicScenePage() {
   // Object editing — position is lifted so drag and popover share it
   const [selectedObjectId, setSelectedObjectId] = useState(null);
   const [editPosition, setEditPosition] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
   const selectedObject = objects.find((o) => o.id === selectedObjectId) || null;
 
   const handleSelect = useCallback(
@@ -103,6 +105,7 @@ export function DynamicScenePage() {
       if (obj) {
         setSelectedObjectId(id);
         setEditPosition([...(obj.position || [0, 0, 0])]);
+        setSaveError(null);
       }
     },
     [objects],
@@ -111,32 +114,47 @@ export function DynamicScenePage() {
   const handleDeselect = useCallback(() => {
     setSelectedObjectId(null);
     setEditPosition(null);
+    setSaveError(null);
   }, []);
 
   const handleObjectUpdate = useCallback(
-    (updated) => {
+    async (updated) => {
       const nextObjects = objects.map((o) => (o.id === updated.id ? updated : o));
-      handleSave({
+      setSaving(true);
+      setSaveError(null);
+      const ok = await handleSave({
         groupOffset: { x: 0, y: 0 },
         groupOffsets: {},
         objects: nextObjects,
         replaceObjects: true,
       });
-      handleDeselect();
+      setSaving(false);
+      if (ok) {
+        handleDeselect();
+      } else {
+        setSaveError('Failed to save — changes not persisted');
+      }
     },
     [objects, handleSave, handleDeselect],
   );
 
   const handleObjectDelete = useCallback(
-    (id) => {
+    async (id) => {
       const nextObjects = objects.filter((o) => o.id !== id);
-      handleSave({
+      setSaving(true);
+      setSaveError(null);
+      const ok = await handleSave({
         groupOffset: { x: 0, y: 0 },
         groupOffsets: {},
         objects: nextObjects,
         replaceObjects: true,
       });
-      handleDeselect();
+      setSaving(false);
+      if (ok) {
+        handleDeselect();
+      } else {
+        setSaveError('Failed to delete — object still present');
+      }
     },
     [objects, handleSave, handleDeselect],
   );
@@ -300,6 +318,27 @@ export function DynamicScenePage() {
           onDelete={handleObjectDelete}
           onClose={handleDeselect}
         />
+      )}
+
+      {(saving || saveError) && (
+        <div
+          style={{
+            position: 'fixed',
+            top: '50px',
+            right: '20px',
+            zIndex: 10003,
+            padding: '6px 12px',
+            borderRadius: '4px',
+            fontSize: '11px',
+            letterSpacing: '1px',
+            fontFamily: theme.typography.fontBody,
+            background: saveError ? 'rgba(255,80,80,0.2)' : 'rgba(0,0,0,0.7)',
+            color: saveError ? '#f55' : theme.colors.textMuted,
+            border: saveError ? '1px solid rgba(255,80,80,0.4)' : '1px solid transparent',
+          }}
+        >
+          {saveError || 'Saving…'}
+        </div>
       )}
 
       <ScrollMinimap


### PR DESCRIPTION
## Summary
- `handleObjectUpdate` and `handleObjectDelete` in `DynamicScenePage` now `await handleSave(...)` before calling `handleDeselect()`, so a failed save no longer hides the user's unsaved edit.
- `useSceneLoader.save` returns `true`/`false` (errors are still logged) so callers can react without a broader refactor; existing fire-and-forget callers are unaffected.
- On failure the object stays selected and a small inline "Failed to save" indicator is shown; while the request is in flight a brief "Saving…" indicator appears.

## Test plan
- [x] `npm run lint` — no new lint issues in changed files (pre-existing warnings/errors in `ClockworkShell.jsx` and `Scene.jsx` unchanged)
- [x] `npm test` — all 15 `useSceneLoader` tests pass; 6 pre-existing failures in `ComicBookReader` and `gcsStorage*` are unrelated and present on the base branch
- [x] `npm run build` — production build succeeds
- [ ] Manual: in dev, edit an object while the PATCH endpoint is unreachable — verify object stays selected and error message appears
- [ ] Manual: happy path — edit and delete still deselect as before

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)