### PR TITLE
feat: expose error state from usePages hook (#83)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -183,7 +183,7 @@ function OverlayControls({ overlayConfig, setOverlayConfig }) {
 /**
  * Page Navigator - for switching between demo pages
  */
-function PageNavigator({ pages }) {
+function PageNavigator({ pages, error }) {
   const { theme } = useTheme();
   const location = useLocation();
   const [publishStatus, setPublishStatus] = useState({});
@@ -367,6 +367,20 @@ function PageNavigator({ pages }) {
           </div>
         </>
       )}
+
+      {error && (
+        <div
+          style={{
+            color: '#ef4444',
+            fontSize: '10px',
+            marginTop: '12px',
+            letterSpacing: '0.5px',
+          }}
+          title={error.message}
+        >
+          ⚠ Failed to load published comics
+        </div>
+      )}
     </div>
   );
 }
@@ -402,7 +416,7 @@ function EditorLayout() {
   });
 
   // Lift scene list here so PageNavigator and NewScenePage share the same state
-  const { pages: allPages, refetch: refetchPages } = usePages();
+  const { pages: allPages, error: pagesError, refetch: refetchPages } = usePages();
 
   // Don't show overlays on depth segmentation page (has its own controls)
   const showOverlays = location.pathname !== '/depth-segmentation';
@@ -433,7 +447,7 @@ function EditorLayout() {
       )}
 
       {/* Page navigation */}
-      <PageNavigator pages={allPages} />
+      <PageNavigator pages={allPages} error={pagesError} />
 
       {/* Main content */}
       <Routes>

--- a/src/hooks/usePages.js
+++ b/src/hooks/usePages.js
@@ -8,12 +8,14 @@ import { listComicBooks } from '../services/gcsStorage';
  * @returns {{
  *   pages: Array<{ slug: string, name: string, source: 'local'|'gcs' }>,
  *   loading: boolean,
+ *   error: Error | null,
  *   refetch: () => void,
  * }}
  */
 export function usePages() {
   const [pages, setPages] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
@@ -21,6 +23,7 @@ export function usePages() {
 
     async function fetchAll() {
       const results = [];
+      let gcsError = null;
 
       // Fetch local pages (dev server only — will 404 in prod, that's fine)
       try {
@@ -51,11 +54,13 @@ export function usePages() {
           results.push({ slug: book.slug, name: book.name, source: 'gcs' });
         }
       } catch (err) {
+        gcsError = err instanceof Error ? err : new Error(String(err));
         console.warn('[usePages] Failed to list GCS comic books:', err);
       }
 
       if (!cancelled) {
         setPages(results);
+        setError(gcsError);
         setLoading(false);
       }
     }
@@ -69,5 +74,5 @@ export function usePages() {
 
   const refetch = useCallback(() => setRefreshTick((t) => t + 1), []);
 
-  return { pages, loading, refetch };
+  return { pages, loading, error, refetch };
 }


### PR DESCRIPTION
## Summary
- Adds an `error` field to the `usePages` hook's return value, so consumers can distinguish between "no pages exist" and "GCS is unreachable".
- The existing try/catch around `listComicBooks()` now captures the failure into state in addition to the existing `console.warn`.
- `PageNavigator` in `App.jsx` opts into the new field and renders a small inline warning row under the PUBLISHED group when GCS fails. Consumers that don't care can keep destructuring only `{ pages, loading, refetch }` — the change is additive.

## Test plan
- [ ] `npm run lint` — no new warnings/errors introduced by this change (pre-existing ClockworkShell/Scene lint issues are unchanged).
- [ ] `npm test` — `226 passed / 6 failed` both before and after this change; the 6 failures are pre-existing in `gcsStorage.test.js` and `gcsStorageWrite.test.js` and are unrelated to this PR.
- [ ] Manual: with dev server running and GCS reachable, PageNavigator shows PUBLISHED links and no warning row.
- [ ] Manual: simulate GCS failure (block network / bad credentials); PageNavigator shows the inline `Failed to load published comics` warning, and the error message is visible in the element's `title` tooltip.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)