### PR TITLE
refactor: extract useImageUpload hook (#81)

### DIFF
--- a/src/components/scene/InsertModals.jsx
+++ b/src/components/scene/InsertModals.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { useTheme } from '../../theme/ThemeContext';
+import { useImageUpload } from '../../hooks/useImageUpload';
 
 const MODAL_OVERLAY_STYLE = {
   position: 'fixed',
@@ -103,36 +104,13 @@ function ModalBase({
 
 export function MemoryCardModal({ onConfirm, onCancel }) {
   const { theme } = useTheme();
-  const [imageDataUrl, setImageDataUrl] = useState(null);
-  const [originalFilename, setOriginalFilename] = useState(null);
+  const { imageDataUrl, uploading, error, handleFileChange, upload } = useImageUpload();
   const [caption, setCaption] = useState('');
-  const [uploading, setUploading] = useState(false);
-  const [error, setError] = useState(null);
-
-  const handleFileChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setOriginalFilename(file.name);
-    const reader = new FileReader();
-    reader.onload = (ev) => setImageDataUrl(ev.target.result);
-    reader.readAsDataURL(file);
-  };
 
   const handleConfirm = async () => {
     if (!imageDataUrl) return;
-    setUploading(true);
-    setError(null);
     try {
-      const res = await fetch('/_dev/assets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ imageUrl: imageDataUrl, filename: originalFilename }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Upload failed');
-      }
-      const { url } = await res.json();
+      const url = await upload();
       onConfirm({
         type: 'memory',
         position: [0, 0, 0],
@@ -140,10 +118,8 @@ export function MemoryCardModal({ onConfirm, onCancel }) {
         panelVariant: 'polaroid',
         data: { imageUrl: url, caption },
       });
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setUploading(false);
+    } catch {
+      // error state is surfaced by the hook
     }
   };
 
@@ -201,56 +177,34 @@ export function MemoryCardModal({ onConfirm, onCancel }) {
 
 export function ImageCardModal({ onConfirm, onCancel }) {
   const { theme } = useTheme();
-  const [imageDataUrl, setImageDataUrl] = useState(null);
-  const [originalFilename, setOriginalFilename] = useState(null);
+  const { imageDataUrl, uploading, error, handleFileChange, upload } = useImageUpload();
   const [naturalWidth, setNaturalWidth] = useState(null);
   const [naturalHeight, setNaturalHeight] = useState(null);
   const [caption, setCaption] = useState('');
   const [scale, setScale] = useState(1);
-  const [uploading, setUploading] = useState(false);
-  const [error, setError] = useState(null);
 
-  const handleFileChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setOriginalFilename(file.name);
-    const reader = new FileReader();
-    reader.onload = (ev) => {
-      const dataUrl = ev.target.result;
-      setImageDataUrl(dataUrl);
-      // Read natural dimensions to preserve aspect ratio
-      const img = new Image();
-      img.onload = () => {
-        // Cap base size so the default fits on screen
-        const maxBase = 400;
-        const ratio = Math.min(maxBase / img.naturalWidth, maxBase / img.naturalHeight, 1);
-        setNaturalWidth(Math.round(img.naturalWidth * ratio));
-        setNaturalHeight(Math.round(img.naturalHeight * ratio));
-        setScale(1);
-      };
-      img.src = dataUrl;
+  // When a new image is loaded, compute the capped natural dimensions so we
+  // preserve aspect ratio while keeping the default render size on-screen.
+  useEffect(() => {
+    if (!imageDataUrl) return;
+    const img = new Image();
+    img.onload = () => {
+      const maxBase = 400;
+      const ratio = Math.min(maxBase / img.naturalWidth, maxBase / img.naturalHeight, 1);
+      setNaturalWidth(Math.round(img.naturalWidth * ratio));
+      setNaturalHeight(Math.round(img.naturalHeight * ratio));
+      setScale(1);
     };
-    reader.readAsDataURL(file);
-  };
+    img.src = imageDataUrl;
+  }, [imageDataUrl]);
 
   const baseW = naturalWidth || 280;
   const baseH = naturalHeight || 200;
 
   const handleConfirm = async () => {
     if (!imageDataUrl) return;
-    setUploading(true);
-    setError(null);
     try {
-      const res = await fetch('/_dev/assets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ imageUrl: imageDataUrl, filename: originalFilename }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Upload failed');
-      }
-      const { url } = await res.json();
+      const url = await upload();
       onConfirm({
         type: 'image',
         position: [0, 0, 0],
@@ -258,10 +212,8 @@ export function ImageCardModal({ onConfirm, onCancel }) {
         panelVariant: 'default',
         data: { imageUrl: url, caption, baseWidth: baseW, baseHeight: baseH, scale },
       });
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setUploading(false);
+    } catch {
+      // error state is surfaced by the hook
     }
   };
 

--- a/src/hooks/useImageUpload.js
+++ b/src/hooks/useImageUpload.js
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Shared hook for image-like uploads to the `/_dev/assets` endpoint.
+ *
+ * Owns file reader state (data URL, filename) and request state
+ * (`uploading`, `error`). `handleFileChange` reads the selected file
+ * as a data URL; `upload` POSTs it and returns the uploaded asset URL
+ * (or throws on failure).
+ *
+ * @returns {{
+ *   imageDataUrl: string | null,
+ *   uploading: boolean,
+ *   error: string | null,
+ *   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void,
+ *   upload: () => Promise<string>,
+ * }}
+ */
+export function useImageUpload() {
+  const [imageDataUrl, setImageDataUrl] = useState(null);
+  const [originalFilename, setOriginalFilename] = useState(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleFileChange = useCallback((e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setOriginalFilename(file.name);
+    setError(null);
+    const reader = new FileReader();
+    reader.onload = (ev) => setImageDataUrl(ev.target.result);
+    reader.readAsDataURL(file);
+  }, []);
+
+  const upload = useCallback(async () => {
+    if (!imageDataUrl) throw new Error('No image selected');
+    setUploading(true);
+    setError(null);
+    try {
+      const res = await fetch('/_dev/assets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imageUrl: imageDataUrl, filename: originalFilename }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Upload failed');
+      }
+      const { url } = await res.json();
+      return url;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    } finally {
+      setUploading(false);
+    }
+  }, [imageDataUrl, originalFilename]);
+
+  return { imageDataUrl, uploading, error, handleFileChange, upload };
+}


### PR DESCRIPTION
## Summary
- Extract `useImageUpload()` in `src/hooks/useImageUpload.js` that owns `imageDataUrl` / `uploading` / `error` / `originalFilename` state and exposes `handleFileChange(event)` + `upload()` (returns the uploaded URL or throws).
- Refactor `MemoryCardModal` and `ImageCardModal` in `src/components/scene/InsertModals.jsx` to consume the hook instead of re-implementing the FileReader + `POST /_dev/assets` flow.
- `ImageCardModal` keeps its aspect-ratio capping by measuring natural dimensions in a `useEffect` keyed on the hook's `imageDataUrl`, so observable behavior (UI, error messages, confirm label, disabled states) is unchanged.
- `VideoCardModal` deliberately untouched — unification is handled by issue #78.

## Test plan
- [x] `npm run lint` — new files/changes clean; only pre-existing `ClockworkShell.jsx` errors remain (out of scope).
- [x] `npm test -- --run src/components/scene/__tests__/InsertModals.test.jsx src/hooks/` — 64/64 passing.
- [x] Full `npm test -- --run` — only pre-existing `ComicBookReader.test.jsx` / `gcsStorage*.test.js` failures remain (out of scope per task brief).
- [ ] Manual smoke test: open a scene, insert a Memory card and an Image card with a local image, verify upload + caption still work end-to-end.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)