### PR TITLE
refactor: extract shared SavedObjectRenderer (#80)

### DIFF
--- a/src/components/scene/SavedObjectRenderer.jsx
+++ b/src/components/scene/SavedObjectRenderer.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { SceneObject } from './SceneObject';
+import { CARD_TYPE_REGISTRY } from './cardTypes';
+
+/**
+ * SavedObjectRenderer - renders a persisted scene object from scene.json's objects array.
+ *
+ * Looks up the card type in CARD_TYPE_REGISTRY, renders its content, and wraps it
+ * in a <SceneObject>. Shared between DynamicScenePage (editor) and ComicBookReader (read-only).
+ *
+ * Props:
+ *   object            — the scene object (required). Expects `type`, optional `position`, `parallaxFactor`, `id`.
+ *   onObjectClick     — read-only click handler: `(objectId) => void`. Used by the reader for theme triggers, etc.
+ *                       Mutually exclusive with `onSelect`; if both are passed, `onSelect` wins (editor mode).
+ *
+ *   Editor-only (all optional — omit for read-only behavior):
+ *   selected          — when true, renders a selection outline and "grab" cursor.
+ *   overridePosition  — overrides `object.position` during drag (editor live-drag feedback).
+ *   onSelect          — click handler: `(objectId) => void`. When passed, the component is in editor mode
+ *                       and adds a transparent overlay div for reliable click capture.
+ *   onDragStart       — drag handler passed through to SceneObject.
+ */
+export function SavedObjectRenderer({
+  object,
+  selected = false,
+  overridePosition,
+  onSelect,
+  onDragStart,
+  onObjectClick,
+}) {
+  const position = overridePosition || object.position || [0, 0, 0];
+  const parallaxFactor = object.parallaxFactor ?? 0.6;
+
+  const cardType = CARD_TYPE_REGISTRY.find((ct) => ct.id === object.type);
+  const content = cardType ? cardType.renderContent(object) : null;
+
+  if (!content) return null;
+
+  // Editor mode is active when `onSelect` is provided. In editor mode we:
+  //   - forward drag handlers
+  //   - render a selection outline when `selected`
+  //   - add a transparent overlay <div> inside the SceneObject to make the
+  //     entire card clickable (avoids card children swallowing clicks).
+  const editorMode = Boolean(onSelect);
+
+  const clickHandler = editorMode
+    ? () => onSelect(object.id)
+    : onObjectClick
+      ? () => onObjectClick(object.id)
+      : undefined;
+
+  const style =
+    editorMode && selected
+      ? {
+          outline: '2px solid var(--color-primary, #ff4081)',
+          outlineOffset: '4px',
+          cursor: 'grab',
+        }
+      : undefined;
+
+  return (
+    <SceneObject
+      position={position}
+      parallaxFactor={parallaxFactor}
+      onClick={clickHandler}
+      onDragStart={editorMode ? onDragStart : undefined}
+      style={style}
+    >
+      {editorMode ? (
+        <div style={{ position: 'relative' }}>
+          {content}
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 10,
+              cursor: 'pointer',
+            }}
+          />
+        </div>
+      ) : (
+        content
+      )}
+    </SceneObject>
+  );
+}
+
+export default SavedObjectRenderer;

--- a/src/components/scene/index.js
+++ b/src/components/scene/index.js
@@ -3,3 +3,4 @@ export { SceneObject, ObjectPresets } from './SceneObject';
 export { SceneObjectGroup, useGroup } from './SceneObjectGroup';
 export { Panel } from './Panel';
 export { InsertToolbar } from './InsertToolbar';
+export { SavedObjectRenderer } from './SavedObjectRenderer';

--- a/src/pages/ComicBookReader.jsx
+++ b/src/pages/ComicBookReader.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Scene, SceneObject } from '../components/scene';
-import { CARD_TYPE_REGISTRY } from '../components/scene/cardTypes';
+import { Scene, SceneObject, SavedObjectRenderer } from '../components/scene';
 import { OverlayStack } from '../components/overlays';
 import { useTheme } from '../theme/ThemeContext';
 import { useComicBook } from '../hooks/useComicBook';
@@ -241,26 +240,6 @@ export function ComicBookReader() {
         ))}
       </Scene>
     </>
-  );
-}
-
-function SavedObjectRenderer({ object, onObjectClick }) {
-  const position = object.position || [0, 0, 0];
-  const parallaxFactor = object.parallaxFactor ?? 0.6;
-
-  const cardType = CARD_TYPE_REGISTRY.find((ct) => ct.id === object.type);
-  const content = cardType ? cardType.renderContent(object) : null;
-
-  if (!content) return null;
-
-  return (
-    <SceneObject
-      position={position}
-      parallaxFactor={parallaxFactor}
-      onClick={onObjectClick ? () => onObjectClick(object.id) : undefined}
-    >
-      {content}
-    </SceneObject>
   );
 }
 

--- a/src/pages/DynamicScenePage.jsx
+++ b/src/pages/DynamicScenePage.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Scene, SceneObject } from '../components/scene';
-import { CARD_TYPE_REGISTRY } from '../components/scene/cardTypes';
+import { Scene, SceneObject, SavedObjectRenderer } from '../components/scene';
 import { ObjectEditPopover } from '../components/scene/InsertModals';
 import { useTheme } from '../theme/ThemeContext';
 import { useSceneLoader } from '../hooks/useSceneLoader';
@@ -308,51 +307,6 @@ export function DynamicScenePage() {
         onSlideClick={jumpToSlide}
       />
     </>
-  );
-}
-
-/**
- * SavedObjectRenderer - renders a persisted scene object from scene.json's objects array.
- */
-function SavedObjectRenderer({ object, selected, overridePosition, onSelect, onDragStart }) {
-  const position = overridePosition || object.position || [0, 0, 0];
-  const parallaxFactor = object.parallaxFactor ?? 0.6;
-
-  const cardType = CARD_TYPE_REGISTRY.find((ct) => ct.id === object.type);
-  const content = cardType ? cardType.renderContent(object) : null;
-
-  if (!content) return null;
-
-  return (
-    <SceneObject
-      position={position}
-      parallaxFactor={parallaxFactor}
-      onClick={onSelect ? () => onSelect(object.id) : undefined}
-      onDragStart={onDragStart}
-      style={
-        selected
-          ? {
-              outline: '2px solid var(--color-primary, #ff4081)',
-              outlineOffset: '4px',
-              cursor: 'grab',
-            }
-          : undefined
-      }
-    >
-      <div style={{ position: 'relative' }}>
-        {content}
-        {onSelect && (
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              zIndex: 10,
-              cursor: 'pointer',
-            }}
-          />
-        )}
-      </div>
-    </SceneObject>
   );
 }
 


### PR DESCRIPTION
## Summary

`SavedObjectRenderer` was defined twice with near-identical implementations in `DynamicScenePage.jsx` and `ComicBookReader.jsx`. Both looked up a card type in `CARD_TYPE_REGISTRY`, called `renderContent`, and wrapped the result in a `SceneObject`. This PR extracts the shared component to `src/components/scene/SavedObjectRenderer.jsx` and imports it from both pages.

- **New file**: `src/components/scene/SavedObjectRenderer.jsx` (exported from `src/components/scene/index.js`)
- **Unified props (union of both call sites)**:
  - `object` (required) — the persisted scene object (`type`, `position`, `parallaxFactor`, `id`).
  - `onObjectClick(id)` — optional read-only click handler. Used by the reader for theme triggers.
  - `selected` — optional; renders selection outline + grab cursor (editor).
  - `overridePosition` — optional; overrides `object.position` during live drag (editor).
  - `onSelect(id)` — optional; when present the component enters editor mode (adds transparent overlay for click capture, forwards drag handlers, honors `selected` outline).
  - `onDragStart` — optional; forwarded to `SceneObject` in editor mode.
- **Defaults to read-only behavior** (reader semantics). Editor mode activates when `onSelect` is provided; `onSelect` takes precedence over `onObjectClick` if both are passed.
- **No rendering-behavior changes** — both call sites now pass the same props they did to the inline defs, and the shared component reproduces each page's prior DOM and wrapper structure:
  - Editor path wraps content in a `position: relative` div with an absolute overlay div (unchanged from the old editor inline version).
  - Reader path renders `{content}` bare inside the `SceneObject` (unchanged from the old reader inline version).

## Test plan

- [x] `npm run lint` — no new errors in changed files. Pre-existing `ClockworkShell.jsx` errors remain (out of scope).
- [x] `npm test` — new component introduces no test regressions. Pre-existing failures in `ComicBookReader.test.jsx`, `gcsStorage.test.js`, and `gcsStorageWrite.test.js` are out of scope.
- [x] `npm run build` — production build succeeds.
- [ ] Manually open a `/scene/:slug` page in edit mode: verify cards render, click-to-select still works, drag still works, selected outline/grab cursor still shows.
- [ ] Manually open a `/read/:comicBookSlug/:slide` page: verify cards render and clicks fire theme triggers via `onObjectClick`.

## Merge notes

This branches off `main` and touches both `DynamicScenePage.jsx` and `ComicBookReader.jsx`. Likely merge conflicts with #82 (DynamicScenePage save await), #85 (SceneObject perf), and #90 (theme triggers), all of which recently edited the same regions. Reviewer to rebase.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)